### PR TITLE
use Gemfile to track dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "debugger"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,16 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    columnize (0.3.6)
+    debugger (1.6.3)
+      columnize (>= 0.3.1)
+      debugger-linecache (~> 1.2.0)
+      debugger-ruby_core_source (~> 1.2.4)
+    debugger-linecache (1.2.0)
+    debugger-ruby_core_source (1.2.4)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  debugger


### PR DESCRIPTION
this way a new person can just run `bundle install` and fetch all appropriate dependencies

You can later setup your project to expose executables such that they always resolve the correct dependencies, I totally forget how though. I think it's part of the bundler magic.
